### PR TITLE
Adding multi domain support for LDAP lookup

### DIFF
--- a/www/auth.php
+++ b/www/auth.php
@@ -4,7 +4,7 @@
  * This page serves as a "HTTP Negotiate" authenticated web page
  * where web server provides the necessary user information. It
  * outputs the URL for the next step of the authentication flow.
- * 
+ *
  * @package SimpleSAMLphp
  */
 
@@ -12,13 +12,13 @@ if (!isset($_REQUEST['State'])) {
     die('Missing State parameter.');
 }
 
-$state = SimpleSAML_Auth_State::loadState($_REQUEST['State'], 'negotiateserver:Negotiate');
+$state = SimpleSAML\Auth\State::loadState($_REQUEST['State'], 'negotiateserver:Negotiate');
 
 if (!empty($_SERVER['REMOTE_USER'])) {
     $state['UserIdentifier'] = $_SERVER['REMOTE_USER'];
 }
 
-$stateId = SimpleSAML_Auth_State::saveState($state, 'negotiateserver:Negotiate');
+$stateId = SimpleSAML\Auth\State::saveState($state, 'negotiateserver:Negotiate');
 
 echo SimpleSAML\Module::getModuleURL('negotiateserver/resume.php', array(
     'State' => $stateId,

--- a/www/fallback.php
+++ b/www/fallback.php
@@ -7,7 +7,7 @@
  * @package SimpleSAMLphp
  */
 
-$state = SimpleSAML_Auth_State::loadState($_REQUEST['State'], 'negotiateserver:Negotiate');
+$state = SimpleSAML\Auth\State::loadState($_REQUEST['State'], 'negotiateserver:Negotiate');
 SimpleSAML\Logger::debug('Negotiate Server: initiating fallback auth source');
 
 sspmod_negotiateserver_Auth_Source_Negotiate::fallback($state);


### PR DESCRIPTION
By using the REALM part of the identity different configured LDAP hosts can be queried.
(The LDAP base domain follows the same logic if necessary.)